### PR TITLE
Update VYNFCNDEFPayloadParser.m

### DIFF
--- a/VYNFCKit/VYNFCNDEFPayloadParser.m
+++ b/VYNFCKit/VYNFCNDEFPayloadParser.m
@@ -563,8 +563,9 @@ uint16_t uint16FromBigEndian(unsigned char*p);
             index += 2;
 
         } else { // Unknown attribute
-            index += 2;
-            return nil;
+            index +=1; //index += 2; Skip just one byte, because after an attribute tag there could be a variable length of attribute information
+            // return nil; just ignore unknown attribute
+            // this change works as long as the attribute info does not include a byte sequence wich is identical to a attribute tag!
         }
     }
 


### PR DESCRIPTION
This change handles issue https://github.com/vinceyuan/VYNFCKit/issues/4 - to ignore unknown attribute tags in wifi simple configuration parser.

There is a low change of conflict in the code because unknown attribute can include additional attribute information of variable length. If this includes a byte sequence wich is equal to an attribute tag, the parser would misinterpret this as an attribute!