### PR TITLE
Rmove plist from source files on podspec file

### DIFF
--- a/VYNFCKit.podspec
+++ b/VYNFCKit.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = "8.0"
   s.source           = { :git => 'https://github.com/VinceYuan/VYNFCKit.git', :tag => s.version.to_s }
-  s.source_files = 'VYNFCKit/**/*'
+  s.source_files = 'VYNFCKit/**/*.h', 'VYNFCKit/**/*.m'
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'


### PR DESCRIPTION
Remove plist from source files on podspec file to get the framework compile with the new Xcode 10 Build System